### PR TITLE
Fix A=牧 evaluation

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -9,10 +9,10 @@
         </form>
         <ul>
             <li>
-                <p> 元のョ米: {{expression.raw}} </p>                
+                <p> 元のョ米: {{expression.raw}} </p>
             </li>
             <li>
-                <p> 胡結果: {{expression.parse(expression.raw).eval()}} </p>                
+                <p> 胡結果: {{expression.parse(expression.raw).eval()}} </p>
             </li>
         </ul>
     </div>
@@ -27,8 +27,8 @@ data () {
             this.rhs = rhs;
         }
         eval(){
-            if(this.lhs.contents !== undefined && this.lhs.contents == 1){
-                return new Sentence(1, undefined, new Round(new Sentence([new Yu(0), new Yu(1),this.rhs,new Yu(0)])));
+            if(this.lhs.terms !== undefined && this.lhs.terms.length === 1 && this.lhs.terms[0].contents === 1){
+                return new Sentence([new Round(new Sentence([new Yu(0), new Yu(1), this.rhs, new Yu(0)]))]);
             }
             var new_lhs = this.rhs.hasTwo() ? new Yu(2): this.lhs;
             var new_rhs = this.lhs.hasTwo() ? new Yu(2): this.rhs;
@@ -145,8 +145,8 @@ data () {
                             break;
                         default:
                             return new ParseError("知らない文字:" + c);
-                    }                    
-                }                
+                    }
+                }
                 console.log(frontier);
                 if(stack.length > 0)return new ParseError("括弧が閉じきっていません．");
                 var eq_pos = frontier.findIndex(x=>x=='=');
@@ -160,7 +160,7 @@ data () {
                 }
             }
         },
-    } 
+    }
 }
 }
 </script>


### PR DESCRIPTION
Fixes https://github.com/catupper/777evaluator/issues/1 .

Added condition for the cases where `lhs` is `Sentence([1])` .

<img width="301" alt="Screenshot 2020-10-04 at 23 19 36" src="https://user-images.githubusercontent.com/36780394/95018189-1199ff00-0699-11eb-80c7-9862685c05c1.png">
<img width="281" alt="Screenshot 2020-10-04 at 23 19 50" src="https://user-images.githubusercontent.com/36780394/95018193-1494ef80-0699-11eb-9367-ff4342dfeee6.png">
